### PR TITLE
Update readme : invalid dependancy

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -49,7 +49,7 @@ Dependency (Maven):
 ```
 <dependency>
     <groupId>de.articdive</groupId>
-    <artifactId>jnoise-pipeline</artifactId>
+    <artifactId>jnoise</artifactId>
     <version>VERSION</version>
 </dependency>
 ```
@@ -66,7 +66,7 @@ Dependency (Gradle Kotlin DSL):
 ```
 dependencies {
     // JNoise Library
-    implementation("de.articdive:jnoise-pipeline:VERSION")
+    implementation("de.articdive:jnoise:VERSION")
 }
 ```
 


### PR DESCRIPTION
# Description
Change the name of the dependancy in the readme.

Why? On maven central the path is jnoise and not jnoise-pipeline, so import from Gradle don't work with the readme code. I don't test with maven but I think there is the same issue.

## Type of pull-request

- [x] Bug fix 
- [ ] New noise type 
- [ ] Adding a new dimension to a noise type
- [ ] Requires an update to the documentation
- [ ] Changes the current output of noise.
- [x] Other

## Which tickets does this PR close?
None

# How Has This Been Tested?
I import Jnoise from gradle and it's work.

**Test Configuration**:
* Java Version: 17
* OS: Windows 10

# Checklist (* = required):
- [x] *I have read and agree to the [contribution guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] *I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] *My changes generate no new warnings and pass the JUnit tests (without altering them).