### PR TITLE
Modularized

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * The core JNoise module. 
+ * 
+ * Requires JSpecify.
+ */
 module de.articdive.jnoise.core {
   exports de.articdive.jnoise.core.api.functions;
   exports de.articdive.jnoise.core.api.modifiers;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module de.articdive.jnoise.core {
+  exports de.articdive.jnoise.core.api.functions;
+  exports de.articdive.jnoise.core.api.modifiers;
+  exports de.articdive.jnoise.core.api.modules;
+  exports de.articdive.jnoise.core.api.noisegen;
+  exports de.articdive.jnoise.core.api.pipeline;
+  exports de.articdive.jnoise.core.api.transformers;
+
+  exports de.articdive.jnoise.core.util;
+  exports de.articdive.jnoise.core.util.vectors;
+
+  requires transitive org.jspecify;
+}

--- a/generators/src/main/java/module-info.java
+++ b/generators/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * The "generators" JNoise module. 
+ * 
+ * Requires the core JNoise module.
+ */
 module de.articdive.jnoise.generators {
   exports de.articdive.jnoise.generators.noise_parameters.distance_functions;
   exports de.articdive.jnoise.generators.noise_parameters.fade_functions;

--- a/generators/src/main/java/module-info.java
+++ b/generators/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+module de.articdive.jnoise.generators {
+  exports de.articdive.jnoise.generators.noise_parameters.distance_functions;
+  exports de.articdive.jnoise.generators.noise_parameters.fade_functions;
+  exports de.articdive.jnoise.generators.noise_parameters.interpolation;
+  exports de.articdive.jnoise.generators.noise_parameters.return_type_functions;
+  exports de.articdive.jnoise.generators.noise_parameters.simplex_variants;
+
+  exports de.articdive.jnoise.generators.noisegen.constant;
+  exports de.articdive.jnoise.generators.noisegen.opensimplex;
+  exports de.articdive.jnoise.generators.noisegen.pattern;
+  exports de.articdive.jnoise.generators.noisegen.perlin;
+  exports de.articdive.jnoise.generators.noisegen.random.gaussian;
+  exports de.articdive.jnoise.generators.noisegen.random.white;
+  exports de.articdive.jnoise.generators.noisegen.value;
+  exports de.articdive.jnoise.generators.noisegen.worley;
+  
+  requires transitive de.articdive.jnoise.core;
+}

--- a/modifiers/src/main/java/module-info.java
+++ b/modifiers/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * The "modifiers" JNoise module. 
+ * 
+ * Requires the core JNoise module.
+ */
 module de.articdive.jnoise.modifiers {
   exports de.articdive.jnoise.modifiers.absolute_value;
   exports de.articdive.jnoise.modifiers.clamp;

--- a/modifiers/src/main/java/module-info.java
+++ b/modifiers/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module de.articdive.jnoise.modifiers {
+  exports de.articdive.jnoise.modifiers.absolute_value;
+  exports de.articdive.jnoise.modifiers.clamp;
+  exports de.articdive.jnoise.modifiers.inverter;
+
+  requires transitive de.articdive.jnoise.core;
+}

--- a/modules/src/main/java/module-info.java
+++ b/modules/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module de.articdive.jnoise.modules {
+  exports de.articdive.jnoise.modules.blend;
+  exports de.articdive.jnoise.modules.combination;
+  exports de.articdive.jnoise.modules.octavation;
+  exports de.articdive.jnoise.modules.octavation.fractal_functions;
+  exports de.articdive.jnoise.modules.selection;
+
+  requires transitive de.articdive.jnoise.core;
+}

--- a/modules/src/main/java/module-info.java
+++ b/modules/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * The "modules" JNoise module. 
+ * 
+ * Requires the core JNoise module.
+ */
 module de.articdive.jnoise.modules {
   exports de.articdive.jnoise.modules.blend;
   exports de.articdive.jnoise.modules.combination;

--- a/pipeline/src/main/java/module-info.java
+++ b/pipeline/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module de.articdive.jnoise.pipelines {
+  exports de.articdive.jnoise.pipeline;
+
+  requires transitive de.articdive.jnoise.core;
+  requires transitive de.articdive.jnoise.transformers;
+  requires transitive de.articdive.jnoise.generators;
+  requires transitive de.articdive.jnoise.modules;
+  requires transitive de.articdive.jnoise.modifiers;
+}

--- a/pipeline/src/main/java/module-info.java
+++ b/pipeline/src/main/java/module-info.java
@@ -1,4 +1,10 @@
-module de.articdive.jnoise.pipelines {
+/**
+ * The "pipeline" JNoise module. 
+ * 
+ * Requires the "core", "transformers", "generators", 
+ * "modules" and "modifiers" JNoise module.
+ */
+module de.articdive.jnoise.pipeline {
   exports de.articdive.jnoise.pipeline;
 
   requires transitive de.articdive.jnoise.core;

--- a/transformers/src/main/java/module-info.java
+++ b/transformers/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * The "transformers" JNoise module. 
+ * 
+ * Requires the core JNoise module.
+ */
 module de.articdive.jnoise.transformers {
   exports de.articdive.jnoise.transformers.domain_warp;
   exports de.articdive.jnoise.transformers.scale;

--- a/transformers/src/main/java/module-info.java
+++ b/transformers/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module de.articdive.jnoise.transformers {
+  exports de.articdive.jnoise.transformers.domain_warp;
+  exports de.articdive.jnoise.transformers.scale;
+
+  requires transitive de.articdive.jnoise.core;
+}


### PR DESCRIPTION
# Description
Adds `module-info.java` files to the six Gradle subprojects of JNoise, allowing modularized downstream projects to seamlessly use this library.

I initially attempted to consume this library via Gradle by `implementation 'de.articdive:jnoise-pipeline:4.1.0` , but my project was in Java 17 and made use of modules itself. And so, `4.1.0` didn't readily interpolate due to missing `module-info.java` files and [Gradle doesn't seem to ingest non-modularized jars in a modularized project](https://discuss.gradle.org/t/automatic-modules-jigsaw-and-gradle/44431/3) well - without resorting to JAR injections, or manipulating the module/class path directly.

The modules correspond to the six Gradle subprojects:
| Subproject Name  | Java Module Name |
| ------------- | ------------- |
| `core`            |    `de.articdive.jnoise.core`|
| `generators`   |   `de.articdive.jnoise.generators`|
| `modifiers`       |   `de.articdive.jnoise.modifiers`|
| `modules`        |   `de.articdive.jnoise.modules`|
| `pipeline`         |   `de.articdive.jnoise.pipeline`|
| `transformers` |   `de.articdive.jnoise.transformers`|

## Type of pull-request
Please check the boxes that apply to your pull-request.

- [ ] Bug fix 
- [ ] New noise type 
- [ ] Adding a new dimension to a noise type
- [ ] Requires an update to the documentation
- [ ] Changes the current output of noise.
- [x] Other

## Which tickets does this PR close?
None

# How Has This Been Tested?
Mainly `gradle clean build` , which runs the test suite of this project.

**Test Configuration**:
* Java Version: 17
* OS: Windows 10

# Checklist (* = required):
- [x] *I have read and agree to the [contribution guidelines](CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] *I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] *My changes generate no new warnings and pass the JUnit tests (without altering them).